### PR TITLE
Display the most recent telegram alert instead of a hard-coded post number

### DIFF
--- a/apiClient/AlertsApi.js
+++ b/apiClient/AlertsApi.js
@@ -1,0 +1,7 @@
+import { apiGetFetch } from "./apiFetch";
+
+export const fetchMissileAlerts = (lang, count) =>
+  apiGetFetch(`/api/v1/missileAlerts`, {
+    lang,
+    count,
+  });

--- a/apiClient/apiFetch.js
+++ b/apiClient/apiFetch.js
@@ -1,9 +1,9 @@
 export const apiGetFetch = async (endpoint, getParams) => {
   const baseUrl = "https://g11d3ghry9.execute-api.us-east-1.amazonaws.com/v1/";
 
-  let url = `${baseUrl}${endpoint}?`;
+  let url = endpoint[0] === "/" ? `${endpoint}?` : `${baseUrl}${endpoint}?`;
   for (const param in getParams)
-    url += `${param}=${getParams[param]}`;
+    url += `${param}=${getParams[param]}&`;
 
   const response = await fetch(url, {
     method: "GET",

--- a/components/TelegramEmbed/index.js
+++ b/components/TelegramEmbed/index.js
@@ -1,0 +1,38 @@
+import { useState, useRef, useEffect } from "react";
+import { useRouter } from "next/router";
+import { localeToTelegramAlertChannel } from "../../utils";
+import { fetchMissileAlerts } from "../../apiClient/AlertsApi";
+
+const TelegramEmbed = () => {
+  const router = useRouter();
+
+  const [postNumber, setPostNumber] = useState();
+  const [scriptLoaded, setScriptLoaded] = useState(false);
+  const ref = useRef();
+
+  useEffect(() => {
+    const fetchData = async () => {
+      const data = await fetchMissileAlerts(router.locale, 1);
+      setPostNumber(data?.alerts[0]?.post);
+    };
+    fetchData();
+  });
+
+  useEffect(() => {
+    if (scriptLoaded || !ref.current || !postNumber)
+      return;
+    const channel = localeToTelegramAlertChannel(router.locale);
+    const tag = document.createElement("script");
+    tag.src = "https://telegram.org/js/telegram-widget.js?15"
+    tag.setAttribute("data-telegram-post", `${channel}/${postNumber}`);
+    tag.setAttribute("data-width", "100%");
+    ref.current.appendChild(tag);
+    setScriptLoaded(true);
+  }, [postNumber]);
+
+  return (
+    <div ref={ref} style={{ maxWidth: "400px", margin: "0 auto" }} />
+  );
+}
+
+export default TelegramEmbed;

--- a/components/TelegramEmbed/index.js
+++ b/components/TelegramEmbed/index.js
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect } from "react";
 import { useRouter } from "next/router";
 import { localeToTelegramAlertChannel } from "../../utils";
 import { fetchMissileAlerts } from "../../apiClient/AlertsApi";
+import Spinner from "../Spinner";
 
 const TelegramEmbed = () => {
   const router = useRouter();
@@ -30,9 +31,9 @@ const TelegramEmbed = () => {
     setScriptLoaded(true);
   }, [postNumber]);
 
-  return (
-    <div ref={ref} style={{ maxWidth: "400px", margin: "0 auto" }} />
-  );
+  return postNumber
+    ? <div ref={ref} style={{ maxWidth: "400px", margin: "0 auto" }} />
+    : <Spinner />;
 }
 
 export default TelegramEmbed;

--- a/components/TelegramEmbed/index.js
+++ b/components/TelegramEmbed/index.js
@@ -16,7 +16,7 @@ const TelegramEmbed = () => {
       setPostNumber(data?.alerts[0]?.post);
     };
     fetchData();
-  });
+  }, []);
 
   useEffect(() => {
     if (scriptLoaded || !ref.current || !postNumber)

--- a/pages/alerts.js
+++ b/pages/alerts.js
@@ -1,12 +1,10 @@
-import { useState, useRef, useEffect } from "react";
-import { useRouter } from "next/router";
 import { useTranslation } from "next-i18next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import Hero from "../components/Hero";
 import Layout from "../components/Layout";
 import MissileAlerts from "../components/MissileAlerts";
 import TelegramAlertLinks from "../components/TelegramAlertLinks";
-import { localeToTelegramAlertChannel } from "../utils";
+import TelegramEmbed from "../components/TelegramEmbed";
 import features from "../configs/features";
 
 export const getStaticProps = async ({ locale }) => ({
@@ -17,22 +15,6 @@ export const getStaticProps = async ({ locale }) => ({
 
 const AlertsPage = () => {
   const { t } = useTranslation();
-  const router = useRouter();
-
-  const [scriptLoaded, setScriptLoaded] = useState(false);
-  const ref = useRef();
-
-  useEffect(() => {
-    if (scriptLoaded || !ref.current)
-      return;
-    const channel = localeToTelegramAlertChannel(router.locale);
-    const tag = document.createElement("script");
-    tag.src = "https://telegram.org/js/telegram-widget.js?15"
-    tag.setAttribute("data-telegram-post", `${channel}/47`);
-    tag.setAttribute("data-width", "100%");
-    ref.current.appendChild(tag);
-    setScriptLoaded(true);
-  });
 
   return (
     <Layout
@@ -54,7 +36,7 @@ const AlertsPage = () => {
             title={t("Choose your language")}
           />
         </div>
-        <div ref={ref} style={{ maxWidth: "400px", margin: "0 auto" }} />
+        <TelegramEmbed />
         {features.liveMissileAlerts &&
           <>
             <div>

--- a/pages/api/v1/missileAlerts.js
+++ b/pages/api/v1/missileAlerts.js
@@ -1,8 +1,6 @@
 import cheerio from "cheerio";
 import { localeToTelegramAlertChannel } from "../../../utils";
 
-const NUM_RESULT_TO_SHOW = 10;
-
 const readDOM = async (locale) => {
   const channel = localeToTelegramAlertChannel(locale);
   const data = await fetch(`https://t.me/s/${channel}`);
@@ -11,24 +9,32 @@ const readDOM = async (locale) => {
   }
 
 const missileAlertsHandler = async (req, res) => {
+  const num_results = req.query.count || 10;
+
   try {
     const $ = await readDOM(req.query.lang || "en");
-    const messages = $(".tgme_widget_message_bubble");
+    const messages = $(".tgme_widget_message");
 
     const result = [];
 
     messages.each((i, elem) => {
       elem = $(elem);
+
       const text = elem.find(".tgme_widget_message_text").html();
       const time = elem.find(".time").html();
+
+      const dataPost = elem[0]?.attribs["data-post"];
+      const post = parseInt(dataPost.split("/")[1]);
+
       result.push({
         text,
         time,
+        post,
       });
     });
 
     res.status(200).json({
-      alerts: result.slice(result.length - NUM_RESULT_TO_SHOW),
+      alerts: result.slice(result.length - num_results),
     });
   } catch (e) {
     res.status(500).json({ error: "Couldn't get missile alerts" + e });


### PR DESCRIPTION
Instead of hard-coding the telegram post number to display on the alerts page, we now fetch the post recent post.