### PR TITLE
Footer links saving translation

### DIFF
--- a/components/Footer/index.js
+++ b/components/Footer/index.js
@@ -20,8 +20,8 @@ const Footer = () => {
           <div className="grid grid-1 md:grid-cols-2 lg:grid-cols-2 gap-8">
             <div>
               <FooterHeader>{t("Useful links")}</FooterHeader>
-              <FooterLink href="/resources">{t("Resources")}</FooterLink>
-              <FooterLink href="/border-information">{t("Border Info")}</FooterLink>
+              <FooterLink href="resources">{t("Resources")}</FooterLink>
+              <FooterLink href="border-information">{t("Border Info")}</FooterLink>
               <FooterLink href={REDDIT_URL}>{t("r/ukraine")}</FooterLink>
               {features.hostARefugee &&
                 <FooterLink href="/#">{t("Host a refugee")}</FooterLink>}

--- a/hooks/useCountryData.js
+++ b/hooks/useCountryData.js
@@ -84,8 +84,8 @@ const useCountryData = ({
   const [selectedCountry, setSelectedCountry] = useState(selectedCountryHash);
 
   useEffect(() => {
-    const nextCountryHash = getHashCountry(defaultCountry, availableCountries);
-    const handler = () => setSelectedCountry(nextCountryHash);
+    const nextCountryHash = () => getHashCountry(defaultCountry, availableCountries);
+    const handler = () => setSelectedCountry(nextCountryHash());
 
     window.addEventListener("hashchange", handler);
     return () => window.removeEventListener("hashchange", handler);

--- a/hooks/useCountryData.js
+++ b/hooks/useCountryData.js
@@ -56,8 +56,7 @@ const allCountries = (() => {
 
 const getHashCountry = (defaultCountry, availableCountries) =>
   (typeof window !== "undefined" &&
-      window.location.hash &&
-      window.location.hash.length === 3 &&
+      window.location.hash?.length === 3 &&
       availableCountries.find(({ code }) =>
         code === window.location.hash.slice(1)))
   ? window.location.hash.slice(1)

--- a/hooks/useCountryData.js
+++ b/hooks/useCountryData.js
@@ -80,12 +80,13 @@ const useCountryData = ({
 
   const [library, setLibrary] = useState({});
 
-  const [selectedCountry, setSelectedCountry] =
-    useState(getHashCountry(defaultCountry, availableCountries));
+  const selectedCountryHash = getHashCountry(defaultCountry, availableCountries);
+  const [selectedCountry, setSelectedCountry] = useState(selectedCountryHash);
 
   useEffect(() => {
-    const handler = () =>
-      setSelectedCountry(getHashCountry(defaultCountry, availableCountries));
+    const nextCountryHash = getHashCountry(defaultCountry, availableCountries);
+    const handler = () => setSelectedCountry(nextCountryHash);
+
     window.addEventListener("hashchange", handler);
     return () => window.removeEventListener("hashchange", handler);
   });
@@ -112,11 +113,10 @@ const useCountryData = ({
 
   const getCountryData = (countryName) => {
     const countries = library[language];
-    if (countries) {
-      const data = countries[countryName];
-      if (data)
-        return data;
-    }
+    const data = countries ? countries[countryName] : null;
+
+    if (data)
+      return data;
 
     fetchCountryData(countryName);
     return null;


### PR DESCRIPTION
When we move on the [border-info or resources] page by footer link, we lost selected translation language. 
Fixed it

P.S. Don't know, why this pull request contains the merge commits and "LocationCard styling". So, if anyone could help - please, welcome